### PR TITLE
adapting key to use same name as used in theme

### DIFF
--- a/exampleSite/data/team.yml
+++ b/exampleSite/data/team.yml
@@ -5,40 +5,40 @@ members  :
     name        : PABLO ESCOBAR
     designation : Creative Director
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/
 
   - image       : images/team/team-member-two.jpg
     name        : MONTINO RIAU
     designation : Product Manager
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/
 
   - image       : images/team/team-member-three.jpg
     name        : ALEX NAASRI
     designation : Chief Design Officer
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/
 
   - image       : images/team/team-member-four.jpg
     name        : HONGMAN CHIOA
     designation : UX Researcher
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/
 
   - image       : images/team/team-member-five.jpg
     name        : SANTIO ANDRESS
     designation : Content Researcher
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/
 
   - image       : images/team/team-member-six.jpg
     name        : RAMESH PAUL
     designation : Creative Designer
     medium      : https://www.medium.com/
-    linkedIn    : https://www.linkedin.com/
+    linkedin    : https://www.linkedin.com/
     instagram   : https://www.instagram.com/


### PR DESCRIPTION
When using the example site, the LinkedIn url wasn't loading properly, I noticed that in the code it called the site data with a `.linkedin` key instead of the `.linkedIn` ( which was in the data folder of the example site ).

Code that called the url:
https://github.com/StaticMania/roxo-hugo/blob/a6d668b124970e1ae9358bc57752e6b11913bd54/layouts/partials/team.html#L24

So, the issue was that all the other links except for the LinkedIn one would work, and the linked in didn't load because the key that was called from the yaml document was with a capitalized `I` for linkedIn.