### PR TITLE
Fix docs path to theme to match `config.toml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ Checkout the live demo [here](https://roxo-hugo.staticmania.com/)
 
 ## Installation
 
-1. Add the repository into your Hugo Project repository as a submodule, `git submodule add git@github.com:StaticMania/roxo-hugo.git themes/roxo`.
+1. Add the repository into your Hugo Project repository as a submodule, `git submodule add git@github.com:StaticMania/roxo-hugo.git themes/roxo-hugo`.
 2. Copy the `data`, `content`, `static`, `resources` & `config.toml` files from the `exampleSite` directory and paste it on you Hugo Project repository/directory. From the site home directory:
 
-    cp -a themes/roxo/exampleSite/* .
+    cp -a themes/roxo-hugo/exampleSite/* .
 
 3. Build your site with `hugo serve` and see the result at `http://localhost:1313/`.
 


### PR DESCRIPTION
The documentation seems to be inconsistent with the `config.toml` file, in that it places the submodule under `themes/roxo` and not `themes/roxo-hugo`, while the config file points to `roxo-hugo` (fixes #25).

Here I assume that the docs got out of sync, so I propose a change in the docs rather than changing the config.toml file instead.