### PR TITLE
Fix `resources.ToCSS()` raising an error because it's longer supported

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,12 +16,14 @@
   {{ "<!-- font-awesome -->" | safeHTML }}
   <link rel="stylesheet" href="{{ "font-awesome/css/font-awesome.min.css" | absURL }}" />
   {{ "<!-- Main Stylesheets -->" | safeHTML }}
-  {{ $style := resources.Get "scss/style.scss" | resources.ToCSS | minify }}
-  <link href="{{ $style.Permalink }}" rel="stylesheet" />
-
-  {{ range .Site.Params.custom_stylesheets -}}
-    {{ $style := resources.Get . | resources.ToCSS | minify }}
-    <link href="{{ $style.Permalink }}" rel="stylesheet" />
+  {{ range (slice "scss/style.scss" | append .Site.Params.custom_stylesheets) -}}
+    {{ $style := resources.Get . | toCSS (dict "transpiler" "libsass" "targetPath" (replaceRE `^scss/(.*)\.scss$` "css/$1.css" .)) }}
+    {{ if hugo.IsDevelopment }}
+      <link href="{{ $style.RelPermalink }}" rel="stylesheet">
+    {{ else }}
+      {{ $style := $style | minify | fingerprint }}
+      <link href="{{ $style.RelPermalink }}" rel="stylesheet" integrity="{{ $style.Data.Integrity }}" crossorigin="anonymous">
+    {{ end }}
   {{- end }}
 
   <!--Favicon-->


### PR DESCRIPTION
Using this great template no longer works since hugo `v0.140.0`. Using it fails with:

```
ERROR deprecated: resources.ToCSS was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use css.Sass instead.
```

This PR replaces `| resources.ToCSS` with `| toCSS`, which is available since hugo `v0.128.0`, making this the minimum required version. Next to using `toCss` and passing a suitable options parameter, this PR improves the current implementation further by

- minifying and fingerprinting the CSS files only if hugo is run in production mode as suggested by https://gohugo.io/functions/css/sass/
- synthesizing the CSS generation for the theme's own `css/style.scss` and the user provided styles defined in the `custom_stylesheets` site parameters into a single CSS block.

The PR has been successfully tested with hugo development and production mode and with additional custom style sheet files via `custom_stylesheets`.