### PR TITLE
docs: add installation instructions specifying hugo.toml (fixes #40)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,28 @@ To contribute effectively, you'll need some prerequisites installed on your mach
 - **Node v18+**: [[https://nodejs.org/en/download/](https://nodejs.org/en/download/)]
 - **Go v1.22+**: [[https://go.dev/doc/install](https://go.dev/doc/install)]
 
+### Installation (as a theme)
+
+To use Roxo in a new Hugo site, install the theme and configure your site with `hugo.toml` (not `config.toml`). The theme expects the Hugo config file to be named `hugo.toml`; using `config.toml` will result in a 404 / "page not found".
+
+```bash
+hugo new site mysite
+cd mysite
+git submodule add https://github.com/furioustheme/roxo-hugo.git themes/roxo-hugo
+```
+
+Then create `hugo.toml` at the root of your site (copy `themes/roxo-hugo/exampleSite/hugo.toml` as a starting point) and set:
+
+```toml
+theme = "roxo-hugo"
+```
+
+Run the site:
+
+```bash
+hugo server
+```
+
 ### Install Dependencies
 
 Install all the necessary dependencies using the following command:


### PR DESCRIPTION
## Summary
- Adds an "Installation (as a theme)" section to the README so new users have explicit steps for installing Roxo as a Hugo theme.
- Calls out that the config file must be `hugo.toml`, not `config.toml`, which is what produced the 404 reported in #40.

Fixes #40.

## Test plan
- [x] `README.md` renders correctly (markdown only — no build impact).
- [x] No code/template changes; existing site behavior unchanged.