### PR TITLE
fix(header): guard against nil Site.Menus.nav (fixes #38)

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -16,9 +16,10 @@
 
     <div class="collapse navbar-collapse" id="sitenavbar">
       <ul class="navbar-nav ml-auto main-nav">
-        {{$menu := (.Site.Menus.nav)}} 
-        {{$len := (len $menu)}} 
-        {{ range $index, $element := $menu }} 
+        {{ $menu := .Site.Menus.nav }}
+        {{ if $menu }}
+        {{ $len := (len $menu) }}
+        {{ range $index, $element := $menu }}
           {{ if eq (add $index 1) $len }}
           <li class="nav-item">
             <a
@@ -38,7 +39,8 @@
               >{{ .Name }}</a
             >
           </li>
-          {{ end }} 
+          {{ end }}
+        {{ end }}
         {{ end }}
       </ul>
     </div>


### PR DESCRIPTION
## Summary
- When a site has no `[[menu.nav]]` entries configured, `.Site.Menus.nav` is nil and calling `len` on it raises `reflect: call of reflect.Value.Type on zero Value`, breaking every page that includes `partials/header.html`.
- Wrapped the menu rendering in `{{ if $menu }}` so the navbar renders without items instead of crashing the build.

Fixes #38.

## Test plan
- [x] With a `hugo.toml` that has no `[[menu.nav]]`, `hugo server` no longer errors on `partials/header.html`.
- [x] With menu entries present, navigation renders unchanged (last entry still gets the primary-button styling).