### PR TITLE
chore: upgrade theme for Hugo v0.161 (latest)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A hugo powered static website.
 
 To contribute effectively, you'll need some prerequisites installed on your machine:
 
-- **Hugo Extended v0.160+**: [[https://gohugo.io/installation/](https://gohugo.io/installation/)]
+- **Hugo Extended v0.161+**: [[https://gohugo.io/installation/](https://gohugo.io/installation/)]
 - **Node v18+**: [[https://nodejs.org/en/download/](https://nodejs.org/en/download/)]
 - **Go v1.22+**: [[https://go.dev/doc/install](https://go.dev/doc/install)]
 

--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -1,5 +1,5 @@
 baseURL       = "/"
-languageCode  = "en-us"
+locale        = "en-us"
 title         = "Roxo | Creative Design Agency"
 theme         = "roxo-hugo"
 summarylength = 25

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ with .Site.LanguageCode }}{{ . }}{{ else }}en-US{{ end }}">
+<html lang="{{ with .Site.Language.Locale }}{{ . }}{{ else }}en-US{{ end }}">
     {{- partial "head.html" . -}}
     <body>
         {{- partial "header.html" . -}}

--- a/theme.toml
+++ b/theme.toml
@@ -6,7 +6,7 @@ description = "Roxo Hugo is a digital agency Hugo theme for creative agencies,  
 homepage = "https://roxo-hugo.netlify.app/"
 tags = ['clean', 'minimal', 'agency', 'corporate', 'creative agency', 'creative studio', 'portfolio', 'staticmania', 'responsive', 'blog', 'customizable', 'company', 'creative', 'agency template']
 features = ['bootstrap 4', 'responsive design', 'blog', 'responsive', 'landing-page', 'minimal', 'business', 'agency-template', 'hugo-theme', 'portfolio', 'company', 'creative', 'contact-form']
-min_version = "0.160.0"
+min_version = "0.161.0"
 
 [author]
   name = "Furioustheme"


### PR DESCRIPTION
## Summary
Upgrade the theme so it builds clean on the latest Hugo (verified on **v0.161.1**, the current stable release).

Hugo v0.158.0 deprecated two APIs the theme was using; both will be removed in a future release and currently emit `WARN deprecated:` messages on every build:

```
WARN  deprecated: project config key languageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use locale instead.
WARN  deprecated: .Site.LanguageCode was deprecated in Hugo v0.158.0 and will be removed in a future release. Use .Site.Language.Locale instead.
```

Changes:
- `exampleSite/hugo.toml` — rename project config key `languageCode` → `locale`.
- `layouts/_default/baseof.html` — replace `.Site.LanguageCode` with `.Site.Language.Locale`.
- `theme.toml` — bump `min_version` to `0.161.0`.
- `README.md` — bump prerequisite to Hugo Extended **v0.161+**.

## Test plan
- [x] `hugo v0.161.1+extended+withdeploy` build of `exampleSite` produces **0 warnings, 0 errors**, all 29 pages render.
- [x] `grep -rn 'resources.ToCSS\|.LanguageCode\|languageCode'` returns no matches.
- [x] No template/layout output changes — only the deprecated APIs are swapped for their replacements.