### PR TITLE
fix(favicon): point to existing PNG and derive MIME from extension (fixes #34)

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -61,7 +61,7 @@ summarylength = 25
 [params]
   logo                  = "images/logo.png"
   logo_footer           = "images/logo-footer.png"
-  favicon_icon          = "images/favicon.ico"
+  favicon_icon          = "images/favicon.png"
   favicon_shortcut_icon = "images/favicon.png"
   custom_stylesheets    = []
   dateFormat            = "26 FEB 1994"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -35,6 +35,11 @@
   {{ end }}
 
   <!--Favicon-->
-  <link rel="shortcut icon" href="{{ .Site.Params.favicon_shortcut_icon | absURL }}" type="image/x-icon" />
-  <link rel="icon" href="{{ .Site.Params.favicon_icon | absURL }}" type="image/x-icon" />
+  {{ $faviconTypes := dict ".ico" "image/x-icon" ".png" "image/png" ".svg" "image/svg+xml" ".gif" "image/gif" ".jpg" "image/jpeg" ".jpeg" "image/jpeg" }}
+  {{ with .Site.Params.favicon_shortcut_icon }}
+  <link rel="shortcut icon" href="{{ . | absURL }}" type="{{ index $faviconTypes (path.Ext .) | default "image/x-icon" }}" />
+  {{ end }}
+  {{ with .Site.Params.favicon_icon }}
+  <link rel="icon" href="{{ . | absURL }}" type="{{ index $faviconTypes (path.Ext .) | default "image/x-icon" }}" />
+  {{ end }}
 </head>


### PR DESCRIPTION
## Summary
The favicon configured by default rendered locally but not on Netlify (issue #34). Two underlying problems:

1. `exampleSite/hugo.toml` referenced `images/favicon.ico`, but only `favicon.png` exists in `static/images/`. On Netlify the missing `.ico` resolves to the SPA-style 404 page (HTML), so browsers never receive a valid icon. Hugo's local dev server short-circuits 404s differently, which is why it appears to work in development.
2. Both `<link>` tags hard-coded `type="image/x-icon"` regardless of the actual file extension, so a PNG was advertised as an `.ico`.

Changes:
- `exampleSite/hugo.toml` — repoint `favicon_icon` to the existing `favicon.png`.
- `layouts/partials/head.html` — derive the `type` attribute from the file extension via a small map; wrap both links in `with` so empty config doesn't render an empty href.

Fixes #34.

## Test plan
- [x] `hugo server` (v0.161.1) — homepage `<link>` tags render as `<link rel=\"shortcut icon\" href=\"//localhost:1313/images/favicon.png\" type=\"image/png\" />` and `<link rel=\"icon\" ...>` similarly.
- [x] `curl -I http://127.0.0.1:1313/images/favicon.png` returns 200.
- [x] No regression: with `favicon_icon = \"images/something.ico\"`, the rendered `type` correctly becomes `image/x-icon`; with the param empty, no `<link>` tag is emitted.