### PR TITLE
fix(ga): accept legacy params key, suppress placeholder IDs (fixes #19)

### DIFF
--- a/exampleSite/hugo.toml
+++ b/exampleSite/hugo.toml
@@ -31,9 +31,13 @@ summarylength = 25
   resampleFilter = "Lanczos"
 
 ######################## Services ################################
+# Set ID to your real Google Analytics measurement ID (e.g. "G-XXXXXXXXXX"
+# for GA4 or "UA-XXXXXXXX-X" for Universal Analytics). Leaving the empty
+# string skips loading the gtag.js snippet. The legacy
+# [params].googleAnalyticsID key is also accepted for backwards compatibility.
 [services]
   [services.googleAnalytics]
-    ID = "YOUR GOOGLE ANALYTICS CODE"
+    ID = ""
 
 ######################## Menus ###################################
 [[menu.nav]]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -24,13 +24,14 @@
   {{- end }}
 
   {{ "<!-- Google Analytics -->" | safeHTML }}
-  {{ with site.Config.Services.GoogleAnalytics.ID }}
-  <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+  {{ $gaID := or site.Config.Services.GoogleAnalytics.ID site.Params.googleAnalyticsID }}
+  {{ if and $gaID (or (hasPrefix $gaID "G-") (hasPrefix $gaID "UA-")) }}
+  <script async src="https://www.googletagmanager.com/gtag/js?id={{ $gaID }}"></script>
   <script>
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-    gtag('config', '{{ . }}');
+    gtag('config', '{{ $gaID }}');
   </script>
   {{ end }}
 


### PR DESCRIPTION
## Summary
Two issues caused Google Analytics not to work as users expected (issue #19):

1. The template in `partials/head.html` only read `site.Config.Services.GoogleAnalytics.ID` (the `[services.googleAnalytics]` block). Users following older docs put the ID under `[params].googleAnalyticsID` and got nothing.
2. `exampleSite/hugo.toml` shipped with `ID = "YOUR GOOGLE ANALYTICS CODE"`. That string is truthy, so the `gtag.js` snippet was emitted on every page with a garbage measurement ID.

Changes:
- `layouts/partials/head.html` — read from `site.Config.Services.GoogleAnalytics.ID` first, fall back to `site.Params.googleAnalyticsID` for the legacy style. Only emit the snippet when the ID looks like a real GA ID (starts with `G-` or `UA-`), so placeholder/empty values don't leak through.
- `exampleSite/hugo.toml` — replace the placeholder string with an empty string and add a comment documenting both supported config locations.

Fixes #19.

## Test plan
- [x] Empty ID (default exampleSite) — no `gtag.js` script tag emitted.
- [x] `[services.googleAnalytics] ID = "G-XXXXXXXX"` — snippet renders with the correct ID.
- [x] Legacy `[params] googleAnalyticsID = "G-TEST12345"` — fallback fires; snippet renders.
- [x] Placeholder string like `"YOUR ID"` — `hasPrefix` check filters it out, no snippet emitted.